### PR TITLE
Feature: Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# Compile image
+# Compiler image
 # -------------------------------------------------------------------------------------------------
-FROM alpine:3.13.5 AS compile-stage
+FROM alpine:3.13.5 AS compiler
 
 WORKDIR /root
 
@@ -21,7 +21,7 @@ RUN /bin/sh ./make_devel.sh
 
 # Runtime image
 # -------------------------------------------------------------------------------------------------
-FROM alpine:3.13.5
+FROM alpine:3.13.5 AS runtime
 
 WORKDIR /root
 
@@ -30,7 +30,7 @@ RUN apk update && \
   apk --update add \
     gmp-dev
 
-COPY --from=compile-stage /root/build /usr/lib/chia-plotter
+COPY --from=compiler /root/build /usr/lib/chia-plotter
 RUN ln -s /usr/lib/chia-plotter/chia_plot /usr/bin/chia_plot
 
-ENTRYPOINT chia_plot
+ENTRYPOINT ["/usr/bin/chia_plot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Compile image
+# -------------------------------------------------------------------------------------------------
+FROM alpine:3.13.5 AS compile-stage
+
+WORKDIR /root
+
+RUN apk update && \
+  apk upgrade && \
+  apk --update add \
+    gcc \
+    g++ \
+    build-base \
+    cmake \
+    gmp-dev \
+    libsodium-dev \
+    libsodium-static \
+    git
+
+COPY . .
+RUN /bin/sh ./make_devel.sh
+
+# Runtime image
+# -------------------------------------------------------------------------------------------------
+FROM alpine:3.13.5
+
+WORKDIR /root
+
+RUN apk update && \
+  apk upgrade && \
+  apk --update add \
+    gmp-dev
+
+COPY --from=compile-stage /root/build /usr/lib/chia-plotter
+RUN ln -s /usr/lib/chia-plotter/chia_plot /usr/bin/chia_plot
+
+ENTRYPOINT chia_plot


### PR DESCRIPTION
This PR adds a Docker Image to improve portability. We can use that image for both Windows and Linux machines.

You can test a preview generated image with the following command on your machine:
```sh
docker run \
  -v <path-to-your-tmp-dir>:/mnt/harvester \
  -v <path-to-your-final-dir>:/mnt/farm \
  odelucca/chia-plotter \
    -t /mnt/harvester/ \
    -d /mnt/farm/ \
    -p <pool-key> \
    -f <farm-key>
```

Of course, you can provide whatever arguments you want after the image name.

Also, you can make an alias, like:
```sh
alias chia-plotter="docker run \
  -v <path-to-your-tmp-dir>:/mnt/harvester \
  -v <path-to-your-final-dir>:/mnt/farm \
  odelucca/chia-plotter"
```

And them call it with:
```sh
chia-plotter <args>
```

I've ran a few tests, and it seems that it doesn't affect the performance :)