### PR TITLE
Optimizing the compilation process for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,10 @@ message(STATUS "Architecture: ${TARGET_ARCH}")
 add_subdirectory(lib/bls-signatures)
 
 find_package(Threads REQUIRED)
+
+if(APPLE)
 find_package(sodium REQUIRED)
+endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-function")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ message(STATUS "Architecture: ${TARGET_ARCH}")
 add_subdirectory(lib/bls-signatures)
 
 find_package(Threads REQUIRED)
+find_package(sodium REQUIRED)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-function")
 

--- a/README.md
+++ b/README.md
@@ -170,10 +170,8 @@ The binaries will end up in `build/`, you can copy them elsewhere freely (on the
 ### macOS Big Sur
 First you need to install a package manager called [Brew](https://brew.sh/) and [Xcode](https://apps.apple.com/app/xcode/id497799835) from the Apple App Store.
 ```bash
-brew install libsodium gmp cmake git autoconf automake libtool
-sudo ln -s /usr/local/include/gmp.h /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/
-sudo ln -s /usr/local/include/sodium.h /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/
-sudo ln -s /usr/local/include/sodium /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/
+brew install libsodium gmp cmake git autoconf automake libtool wget
+wget https://raw.githubusercontent.com/facebookincubator/fizz/master/build/fbcode_builder/CMake/FindSodium.cmake -O /usr/local/opt/cmake/share/cmake/Modules/FindSodium.cmake
 git clone https://github.com/madMAx43v3r/chia-plotter.git 
 cd chia-plotter
 git submodule update --init

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ The binaries will end up in `build/`, you can copy them elsewhere freely (on the
 First you need to install a package manager called [Brew](https://brew.sh/) and [Xcode](https://apps.apple.com/app/xcode/id497799835) from the Apple App Store.
 ```bash
 brew install libsodium gmp cmake git autoconf automake libtool wget
+brew link cmake
 wget https://raw.githubusercontent.com/facebookincubator/fizz/master/build/fbcode_builder/CMake/FindSodium.cmake -O /usr/local/opt/cmake/share/cmake/Modules/FindSodium.cmake
 git clone https://github.com/madMAx43v3r/chia-plotter.git 
 cd chia-plotter


### PR DESCRIPTION
I am using macOS 10.15.7, when I tried to compile, I got the following error.

> fatal error: 'sodium.h' file not found
> #include <sodium.h>
>          ^~~~~~~~~~
> 1 error generated.
> make[2]: *** [CMakeFiles/chia_plot.dir/src/chia_plot.cpp.o] Error 1
> make[1]: *** [CMakeFiles/chia_plot.dir/all] Error 2

The reason is that libsodium cannot be found.

I fixed CMakeLists.txt to solve this problem.

If you think this is useful, please merge it.

Thx


