### PR TITLE
Intel and M1 homebrew location differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,10 @@ First you need to install a package manager called [Brew](https://brew.sh/) and 
 ```bash
 brew install libsodium gmp cmake git autoconf automake libtool wget
 brew link cmake
+```
 
+Confirm which directory to use before applying following line
+```
 wget https://raw.githubusercontent.com/facebookincubator/fizz/master/build/fbcode_builder/CMake/FindSodium.cmake -O /usr/local/opt/cmake/share/cmake/Modules/FindSodium.cmake
  or
 wget https://raw.githubusercontent.com/facebookincubator/fizz/master/build/fbcode_builder/CMake/FindSodium.cmake -O /opt/homebrew/Cellar/cmake/3.20.3/share/cmake/Modules/FindSodium.cmake

--- a/README.md
+++ b/README.md
@@ -189,8 +189,6 @@ wget https://raw.githubusercontent.com/facebookincubator/fizz/master/build/fbcod
  or
 wget https://raw.githubusercontent.com/facebookincubator/fizz/master/build/fbcode_builder/CMake/FindSodium.cmake -O /opt/homebrew/Cellar/cmake/3.20.3/share/cmake/Modules/FindSodium.cmake
 
-
-
 git clone https://github.com/madMAx43v3r/chia-plotter.git 
 cd chia-plotter
 git submodule update --init

--- a/README.md
+++ b/README.md
@@ -186,12 +186,16 @@ brew install libsodium gmp cmake git autoconf automake libtool wget
 brew link cmake
 ```
 
-Confirm which directory to use before applying following line
+Confirm which directory you have on YOUR Mac before applying following commands
 ```
 wget https://raw.githubusercontent.com/facebookincubator/fizz/master/build/fbcode_builder/CMake/FindSodium.cmake -O /usr/local/opt/cmake/share/cmake/Modules/FindSodium.cmake
+```
  or
+``` 
 wget https://raw.githubusercontent.com/facebookincubator/fizz/master/build/fbcode_builder/CMake/FindSodium.cmake -O /opt/homebrew/Cellar/cmake/3.20.3/share/cmake/Modules/FindSodium.cmake
+```
 
+```
 git clone https://github.com/madMAx43v3r/chia-plotter.git 
 cd chia-plotter
 git submodule update --init

--- a/README.md
+++ b/README.md
@@ -184,7 +184,13 @@ First you need to install a package manager called [Brew](https://brew.sh/) and 
 ```bash
 brew install libsodium gmp cmake git autoconf automake libtool wget
 brew link cmake
+
 wget https://raw.githubusercontent.com/facebookincubator/fizz/master/build/fbcode_builder/CMake/FindSodium.cmake -O /usr/local/opt/cmake/share/cmake/Modules/FindSodium.cmake
+ or
+wget https://raw.githubusercontent.com/facebookincubator/fizz/master/build/fbcode_builder/CMake/FindSodium.cmake -O /opt/homebrew/Cellar/cmake/3.20.3/share/cmake/Modules/FindSodium.cmake
+
+
+
 git clone https://github.com/madMAx43v3r/chia-plotter.git 
 cd chia-plotter
 git submodule update --init


### PR DESCRIPTION
My Intel MBP16 and M1 minis have different locations to store cmake modules， therefore I add

"/opt/homebrew/Cellar/cmake/3.20.3/share/cmake/Modules/FindSodium.cmake"

here to help M1 users. 2 of my M1 rigs have successfully  run with this directory.