### PR TITLE
Fix memory size in example docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ So, for example, the following command:
 docker run \
   -v <path-to-your-tmp-dir>:/mnt/harvester \
   -v <path-to-your-final-dir>:/mnt/farm \
-  -m 8000 \
+  -m 8G \
   --cpus 8 \
   odelucca/chia-plotter \
     -t /mnt/harvester/ \


### PR DESCRIPTION
Docker memory size is specified in bytes: https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources