### PR TITLE
Update readme.md for CentOS 8 installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ scl enable devtoolset-7 bash
 ./build/chia_plot --help
 ```
 ---
+
+### CentOS 8
+How to install chia-Plotter on CentOS 8
+
 ### Clear Linux
 Read [install file](doc/install_clearlinux.md)
 


### PR DESCRIPTION
Hallo Max,

we chatted in the discord channel about a PR for the CentOS 8 installation guide.

Currently, I can't install the chia-plotter under CentOS 8. Could you please update the installation guide for CentOS 8?

There are several dependencies not available or not required any more for CentOS 8. I had to install Cmake and I used this HowTo-Article `https://www.osradar.com/how-to-install-cmake-on-centos-8/`. Nevertheless, after the execution of `./make_devel.sh`, I get the following error: `/usr/bin/ar: /usr/lib64/libgmp.so File format not recognized` and the script returns `Error 2`.

Thank you very much in advance for your help. I really appreciate, that you provide this piece of software to us.

Best regards

4thHorseman