### PR TITLE
add tmptoggle option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Usage:
   -d, --finaldir arg   Final directory (default = <tmpdir>)
   -p, --poolkey arg    Pool Public Key (48 bytes)
   -f, --farmerkey arg  Farmer Public Key (48 bytes)
+  -G, --tmptoggle      Alternate tmpdir/tmpdir2 (default = false)
       --help           Print help
 ```
 

--- a/src/chia_plot.cpp
+++ b/src/chia_plot.cpp
@@ -165,6 +165,7 @@ int main(int argc, char** argv)
 	int num_plots = 1;
 	int num_threads = 4;
 	int num_buckets = 256;
+	bool tmptoggle;
 	
 	options.allow_unrecognised_options().add_options()(
 		"n, count", "Number of plots to create (default = 1, -1 = infinite)", cxxopts::value<int>(num_plots))(
@@ -175,6 +176,7 @@ int main(int argc, char** argv)
 		"d, finaldir", "Final directory (default = <tmpdir>)", cxxopts::value<std::string>(final_dir))(
 		"p, poolkey", "Pool Public Key (48 bytes)", cxxopts::value<std::string>(pool_key_str))(
 		"f, farmerkey", "Farmer Public Key (48 bytes)", cxxopts::value<std::string>(farmer_key_str))(
+		"G, tmptoggle", "Alternate tmpdir/tmpdir2", cxxopts::value<bool>(tmptoggle)->default_value("false"))(
 		"help", "Print help");
 	
 	if(argc <= 1) {
@@ -344,6 +346,10 @@ int main(int argc, char** argv)
 			break;
 		}
 		std::cout << "Crafting plot " << i+1 << " out of " << num_plots << std::endl;
+		if (tmptoggle && (i % 2 == 1)) {
+			tmp_dir.swap(tmp_dir2);
+		}
+
 		const auto out = create_plot(num_threads, log_num_buckets, pool_key, farmer_key, tmp_dir, tmp_dir2);
 		
 		if(final_dir != tmp_dir)

--- a/src/chia_plot.cpp
+++ b/src/chia_plot.cpp
@@ -346,9 +346,6 @@ int main(int argc, char** argv)
 			break;
 		}
 		std::cout << "Crafting plot " << i+1 << " out of " << num_plots << std::endl;
-		if (tmptoggle && (i % 2 == 1)) {
-			tmp_dir.swap(tmp_dir2);
-		}
 
 		const auto out = create_plot(num_threads, log_num_buckets, pool_key, farmer_key, tmp_dir, tmp_dir2);
 		
@@ -357,6 +354,9 @@ int main(int argc, char** argv)
 			const auto dst_path = final_dir + out.params.plot_name + ".plot";
 			std::cout << "Started copy to " << dst_path << std::endl;
 			copy_thread.take_copy(std::make_pair(out.plot_file_name, dst_path));
+		}
+		if (tmptoggle) {
+			tmp_dir.swap(tmp_dir2);
 		}
 	}
 	copy_thread.close();


### PR DESCRIPTION
For configurations utilizing similar devices for tmpdir and tmdir_2, it may be desirable to spread the write wear evenly between the 2.  When combined with -n > 1, This option swaps the values of -t and -2 for each new plot, spreading the load evenly.