### PR TITLE
Fix possible wrong repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ git submodule update --init
 ---
 ### CentOS 7
 ```bash
-git clone https://github.com/dendil/chia-plotter.git
+git clone https://github.com/madMAx43v3r/chia-plotter.git
 cd chia-plotter
 
 git submodule update --init


### PR DESCRIPTION
The CentOS 7 install section pointed to a different repository - taking a look at that repository did not reveal any commits that would indicate any special optimizations for CentOS 7. The alternate repo is also several commits behind. If this was deliberate (e.g. recent commit broke CentOS 7 and as such old repo is used) then let me know and I will close this PR.