### PR TITLE
Update CMakeList.txt for latest relic commit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ project(chia-plotter C CXX ASM)
 set(TARGET_ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
 message(STATUS "Architecture: ${TARGET_ARCH}")
 
+set(ENV{RELIC_MAIN} "1")
 add_subdirectory(lib/bls-signatures)
 
 find_package(Threads REQUIRED)


### PR DESCRIPTION
This will trigger:
https://github.com/madMAx43v3r/bls-signatures/blob/d9e42922e4a21fe8fc50733b93c16f582022621f/src/CMakeLists.txt#L8

So the plotter can be built with GCC 11.1.1 (Fedora 34)

Closes https://github.com/madMAx43v3r/chia-plotter/issues/70