### PR TITLE
Simplify Clear Linux installation instructions

### DIFF
--- a/doc/install_clearlinux.md
+++ b/doc/install_clearlinux.md
@@ -2,36 +2,15 @@
 
 ```bash
 sudo swupd update
-
-sudo swupd bundle-add c-extras-gcc10
-sudo swupd bundle-add devpkg-libsodium
-
-sudo swupd bundle-add git
-sudo swupd bundle-add wget
-sudo swupd bundle-add zip
-
-# Use gcc10 during build
-export CC=gcc-10
-export CXX=g++-10
-
-
-# Install gmp
-cd /tmp
-wget https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz
-tar -xvf gmp-6.2.1.tar.xz
-cd gmp-6.2.1
-./configure
-make && make check
-sudo make install
+sudo swupd bundle-add c-basic devpkg-libsodium git wget
 
 echo PATH=$PATH:/usr/local/bin/ # for statically compiled cmake if not already in your PATH
-sudo ln -sf /usr/local/lib/libgmp.so.10.4.1 /usr/lib64/libgmp.so
 
 # Install libsodium
 cd /tmp
 wget https://download.libsodium.org/libsodium/releases/LATEST.tar.gz
 tar -xvf LATEST.tar.gz
-cd libsodium-stable/
+cd libsodium-stable
 ./configure
 make && make check
 sudo make install
@@ -39,9 +18,9 @@ sudo make install
 # Checkout the source and install
 cd ~/
 git clone https://github.com/madMAx43v3r/chia-plotter.git 
-cd ~/chia-plotter/
+cd ~/chia-plotter
 git submodule update --init
 
 ./make_devel.sh
-./build/chia_plot  --help
+./build/chia_plot --help
 ```


### PR DESCRIPTION
Thanks to https://github.com/madMAx43v3r/chia-plotter/pull/524 this can now be built with GCC 11.1.1 (Clear Linux 34740) so we can simplify the instructions. Tested OK.