### PR TITLE
Moving .p2.t2.sort_bucket_xxx.tmp to temp2 to speed up a little

### DIFF
--- a/include/chia/phase2.hpp
+++ b/include/chia/phase2.hpp
@@ -154,7 +154,7 @@ void compute(	const phase1::output_t& input, output_t& out,
 	for(int i = 5; i >= 1; --i)
 	{
 		std::swap(curr_bitfield, next_bitfield);
-		out.sort[i] = std::make_shared<DiskSortT>(32, log_num_buckets, prefix + "t" + std::to_string(i + 1));
+		out.sort[i] = std::make_shared<DiskSortT>(32, log_num_buckets, (i == 1 ? prefix_2 : prefix) + "t" + std::to_string(i + 1));
 		
 		compute_table<phase1::tmp_entry_x, entry_x, DiskSortT>(
 			i + 1, num_threads, out.sort[i].get(), nullptr, input.table[i], next_bitfield.get(), curr_bitfield.get());


### PR DESCRIPTION
Assuming that there is a 110G RamDisk for temp2, moving .p2.t2.sort_bucket_xxx.tmp to temp2 will speed up about 10 to 20 seconds.

The change would be really easy, just change the phase2.hpp line below near the bottom from:
out.sort[i] = std::make_shared(32, log_num_buckets, prefix + "t" + std::to_string(i + 1));
to
out.sort[i] = std::make_shared(32, log_num_buckets, (i == 1 ? prefix_2 : prefix) + "t" + std::to_string(i + 1));

This moves about 40G from temp1 and temp2 and will not exceed the 110G limit. I tried a bucket size of 512 and then 128 and both work fine.