### PR TITLE
Added option to wait for copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Usage:
   -t, --tmpdir arg     Temporary directory, needs ~220 GiB (default = $PWD)
   -2, --tmpdir2 arg    Temporary directory 2, needs ~110 GiB [RAM] (default = <tmpdir>)
   -d, --finaldir arg   Final directory (default = <tmpdir>)
+  -w, --waitforcopy    Wait for copy to start next plot
   -p, --poolkey arg    Pool Public Key (48 bytes)
   -f, --farmerkey arg  Farmer Public Key (48 bytes)
   -G, --tmptoggle      Alternate tmpdir/tmpdir2 (default = false)

--- a/src/chia_plot.cpp
+++ b/src/chia_plot.cpp
@@ -168,7 +168,6 @@ int main(int argc, char** argv)
 	std::string tmp_dir;
 	std::string tmp_dir2;
 	std::string final_dir;
-	std::string z;
 	int num_plots = 1;
 	int num_threads = 4;
 	int num_buckets = 256;

--- a/src/chia_plot.cpp
+++ b/src/chia_plot.cpp
@@ -168,10 +168,12 @@ int main(int argc, char** argv)
 	std::string tmp_dir;
 	std::string tmp_dir2;
 	std::string final_dir;
+	std::string z;
 	int num_plots = 1;
 	int num_threads = 4;
 	int num_buckets = 256;
 	int num_buckets_3 = 0;
+	bool waitforcopy = false;
 	bool tmptoggle = false;
 	
 	options.allow_unrecognised_options().add_options()(
@@ -182,6 +184,7 @@ int main(int argc, char** argv)
 		"t, tmpdir", "Temporary directory, needs ~220 GiB (default = $PWD)", cxxopts::value<std::string>(tmp_dir))(
 		"2, tmpdir2", "Temporary directory 2, needs ~110 GiB [RAM] (default = <tmpdir>)", cxxopts::value<std::string>(tmp_dir2))(
 		"d, finaldir", "Final directory (default = <tmpdir>)", cxxopts::value<std::string>(final_dir))(
+		"w, waitforcopy", "Wait for copy to start next plot", cxxopts::value<bool>(waitforcopy))(
 		"p, poolkey", "Pool Public Key (48 bytes)", cxxopts::value<std::string>(pool_key_str))(
 		"f, farmerkey", "Farmer Public Key (48 bytes)", cxxopts::value<std::string>(farmer_key_str))(
 		"G, tmptoggle", "Alternate tmpdir/tmpdir2", cxxopts::value<bool>(tmptoggle))(
@@ -375,6 +378,9 @@ int main(int argc, char** argv)
 			const auto dst_path = final_dir + out.params.plot_name + ".plot";
 			std::cout << "Started copy to " << dst_path << std::endl;
 			copy_thread.take_copy(std::make_pair(out.plot_file_name, dst_path));
+			if(waitforcopy) {
+				copy_thread.wait();
+			}
 		}
 		else if(tmptoggle) {
 			final_dir = tmp_dir2;
@@ -387,5 +393,3 @@ int main(int argc, char** argv)
 	
 	return 0;
 }
-
-


### PR DESCRIPTION
Added a wait until copy file to final destination is completed, this is useful for single tmp directory, as it doesn't have to split the io.
If the user desires, just put the -w flag