### PR TITLE
publish docker images from the pool-puzzles branch

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, pool-puzzles ]
     tags:
       - '*'
   pull_request:


### PR DESCRIPTION
A lot of users want to use that preview branch.