### PR TITLE
Added a --version option for displaying version info

### DIFF
--- a/include/version.hpp
+++ b/include/version.hpp
@@ -2,4 +2,4 @@
 
 #include <string>
 
-const std::string kVersion = "2021.08.25-chia";
+const std::string kVersion = "2021.08.25";

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <string>
+
+const std::string kVersion = "2021.08.25-chia";

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -2,4 +2,4 @@
 
 #include <string>
 
-const std::string kVersion = "2021.08.25";
+const std::string kVersion = "1.1.6" "-" GIT_COMMIT_HASH;

--- a/src/chia_plot.cpp
+++ b/src/chia_plot.cpp
@@ -16,6 +16,7 @@
 #include <sodium.h>
 #include <cxxopts.hpp>
 #include <libbech32.h>
+#include <version.hpp>
 
 #include <string>
 #include <csignal>
@@ -253,6 +254,7 @@ int main(int argc, char** argv)
 		"f, farmerkey", "Farmer Public Key (48 bytes)", cxxopts::value<std::string>(farmer_key_str))(
 		"G, tmptoggle", "Alternate tmpdir/tmpdir2", cxxopts::value<bool>(tmptoggle))(
 		"K, rmulti2", "Thread multiplier for P2 (default = 1)", cxxopts::value<int>(phase2::g_thread_multi))(
+		"version", "Print version")(
 		"help", "Print help");
 	
 	if(argc <= 1) {
@@ -263,6 +265,10 @@ int main(int argc, char** argv)
 	
 	if(args.count("help")) {
 		std::cout << options.help({""}) << std::endl;
+		return 0;
+	}
+	if(args.count("version")) {
+		std::cout << kVersion << std::endl;
 		return 0;
 	}
 	if(k > 32 || k < 16) {


### PR DESCRIPTION
We'd like to display a version string for the madmax plotter in the Chia GUI and CLI. It wasn't immediately obvious where to pull an actual version from, so this PR introduces a --version option that emits a version string. For the moment the version string just references the date of the last commit made, but this could easily be changed to some other versioning scheme.

Is this a change that would be welcomed, or should we handle this separately/on our own?