### PR TITLE
Add -s stagedir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Usage:
   -t, --tmpdir arg     Temporary directory, needs ~220 GiB (default = $PWD)
   -2, --tmpdir2 arg    Temporary directory 2, needs ~110 GiB [RAM] (default = <tmpdir>)
   -d, --finaldir arg   Final directory (default = <tmpdir>)
+  -s, --stagedir arg   Stage directory (default = <finaldir>)
   -w, --waitforcopy    Wait for copy to start next plot
   -p, --poolkey arg    Pool Public Key (48 bytes)
   -c, --contract arg   Pool Contract Address (62 chars)

--- a/src/chia_plot.cpp
+++ b/src/chia_plot.cpp
@@ -264,7 +264,7 @@ int main(int argc, char** argv)
 		"t, tmpdir", "Temporary directory, needs ~220 GiB (default = $PWD)", cxxopts::value<std::string>(tmp_dir))(
 		"2, tmpdir2", "Temporary directory 2, needs ~110 GiB [RAM] (default = <tmpdir>)", cxxopts::value<std::string>(tmp_dir2))(
 		"d, finaldir", "Final directory (default = <tmpdir>)", cxxopts::value<std::string>(final_dir))(
-		"s, stagedir", "Stage directory (default = <finaldir>)", cxxopts::value<std::string>(stage_dir))(
+		"s, stagedir", "Stage directory (default = <tmpdir>)", cxxopts::value<std::string>(stage_dir))(
 		"w, waitforcopy", "Wait for copy to start next plot", cxxopts::value<bool>(waitforcopy))(
 		"p, poolkey", "Pool Public Key (48 bytes)", cxxopts::value<std::string>(pool_key_str))(
 		"c, contract", "Pool Contract Address (62 chars)", cxxopts::value<std::string>(contract_addr_str))(

--- a/src/chia_plot.cpp
+++ b/src/chia_plot.cpp
@@ -503,8 +503,9 @@ int main(int argc, char** argv)
 	}
 	std::cout << std::endl;
 	std::cout << "Final Directory: " << final_dir << std::endl;
-	if (final_dir != stage_dir)
+	if (final_dir != stage_dir) {
 		std::cout << "Stage Directory: " << stage_dir << std::endl;
+	}
 	if(num_plots >= 0) {
 		std::cout << "Number of Plots: " << num_plots << std::endl;
 	} else {

--- a/src/chia_plot.cpp
+++ b/src/chia_plot.cpp
@@ -317,7 +317,7 @@ int main(int argc, char** argv)
 		final_dir = tmp_dir;
 	}
 	if(stage_dir.empty()) {
-		stage_dir = final_dir;
+		stage_dir = tmp_dir;
 	}
 	if(num_buckets_3 <= 0) {
 		num_buckets_3 = num_buckets;

--- a/src/chia_plot.cpp
+++ b/src/chia_plot.cpp
@@ -503,7 +503,7 @@ int main(int argc, char** argv)
 	}
 	std::cout << std::endl;
 	std::cout << "Final Directory: " << final_dir << std::endl;
-	if (!final_dir.compare(stage_dir))
+	if (final_dir != stage_dir)
 		std::cout << "Stage Directory: " << stage_dir << std::endl;
 	if(num_plots >= 0) {
 		std::cout << "Number of Plots: " << num_plots << std::endl;

--- a/src/chia_plot.cpp
+++ b/src/chia_plot.cpp
@@ -316,6 +316,10 @@ int main(int argc, char** argv)
 	if(final_dir.empty()) {
 		final_dir = tmp_dir;
 	}
+	if(!stage_dir.empty() && tmptoggle) {
+		std::cout << "Stagedir and tmptoggle are mutually exclusive options." << std::endl;
+		return -2;
+	}
 	if(stage_dir.empty()) {
 		stage_dir = tmp_dir;
 	}
@@ -372,10 +376,6 @@ int main(int argc, char** argv)
 	}
 	if(!stage_dir.empty() && stage_dir.find_last_of("/\\") != stage_dir.size() - 1) {
 		std::cout << "Invalid stagedir: " << stage_dir << " (needs trailing '/' or '\\')" << std::endl;
-		return -2;
-	}
-	if(!stage_dir.empty() && tmptoggle) {
-		std::cout << "Stagedir and tmptoggle are mutually exclusive options." << std::endl;
 		return -2;
 	}
 	if(num_threads < 1 || num_threads > 1024) {

--- a/src/chia_plot.cpp
+++ b/src/chia_plot.cpp
@@ -242,6 +242,7 @@ int main(int argc, char** argv)
 	std::string tmp_dir;
 	std::string tmp_dir2;
 	std::string final_dir;
+	std::string stage_dir;
 	int k = 32;
 	int port = 8444;			// 8444 = chia, 9699 = chives
 	int num_plots = 1;
@@ -263,6 +264,7 @@ int main(int argc, char** argv)
 		"t, tmpdir", "Temporary directory, needs ~220 GiB (default = $PWD)", cxxopts::value<std::string>(tmp_dir))(
 		"2, tmpdir2", "Temporary directory 2, needs ~110 GiB [RAM] (default = <tmpdir>)", cxxopts::value<std::string>(tmp_dir2))(
 		"d, finaldir", "Final directory (default = <tmpdir>)", cxxopts::value<std::string>(final_dir))(
+		"s, stagedir", "Stage directory (default = <finaldir>)", cxxopts::value<std::string>(stage_dir))(
 		"w, waitforcopy", "Wait for copy to start next plot", cxxopts::value<bool>(waitforcopy))(
 		"p, poolkey", "Pool Public Key (48 bytes)", cxxopts::value<std::string>(pool_key_str))(
 		"c, contract", "Pool Contract Address (62 chars)", cxxopts::value<std::string>(contract_addr_str))(
@@ -313,6 +315,9 @@ int main(int argc, char** argv)
 	}
 	if(final_dir.empty()) {
 		final_dir = tmp_dir;
+	}
+	if(stage_dir.empty()) {
+		stage_dir = final_dir;
 	}
 	if(num_buckets_3 <= 0) {
 		num_buckets_3 = num_buckets;
@@ -365,6 +370,14 @@ int main(int argc, char** argv)
 		std::cout << "Invalid finaldir: " << final_dir << " (needs trailing '/' or '\\')" << std::endl;
 		return -2;
 	}
+	if(!stage_dir.empty() && stage_dir.find_last_of("/\\") != stage_dir.size() - 1) {
+		std::cout << "Invalid stagedir: " << stage_dir << " (needs trailing '/' or '\\')" << std::endl;
+		return -2;
+	}
+	if(!stage_dir.empty() && tmptoggle) {
+		std::cout << "Stagedir and tmptoggle are mutually exclusive options." << std::endl;
+		return -2;
+	}
 	if(num_threads < 1 || num_threads > 1024) {
 		std::cout << "Invalid threads parameter: " << num_threads << " (supported: [1..1024])" << std::endl;
 		return -2;
@@ -404,6 +417,16 @@ int main(int argc, char** argv)
 			remove(path.c_str());
 		} else {
 			std::cout << "Failed to write to finaldir directory: '" << final_dir << "'" << std::endl;
+			return -2;
+		}
+	}
+	{
+		const std::string path = stage_dir + ".chia_plot_final";
+		if(auto file = fopen(path.c_str(), "wb")) {
+			fclose(file);
+			remove(path.c_str());
+		} else {
+			std::cout << "Failed to write to stagedir directory: '" << stage_dir << "'" << std::endl;
 			return -2;
 		}
 	}
@@ -480,6 +503,8 @@ int main(int argc, char** argv)
 	}
 	std::cout << std::endl;
 	std::cout << "Final Directory: " << final_dir << std::endl;
+	if (!final_dir.compare(stage_dir))
+		std::cout << "Stage Directory: " << stage_dir << std::endl;
 	if(num_plots >= 0) {
 		std::cout << "Number of Plots: " << num_plots << std::endl;
 	} else {
@@ -518,9 +543,9 @@ int main(int argc, char** argv)
 				<< " (" << get_date_string_ex("%Y/%m/%d %H:%M:%S") << ")" << std::endl;
 		const auto out = create_plot(
 				k, port, make_unique, num_threads, log_num_buckets, log_num_buckets_3,
-				pool_key, puzzle_hash, farmer_key, tmp_dir, tmp_dir2, directout ? final_dir : tmp_dir);
+				pool_key, puzzle_hash, farmer_key, tmp_dir, tmp_dir2, directout ? final_dir : stage_dir);
 		
-		if(final_dir != tmp_dir)
+		if(final_dir != stage_dir)
 		{
 			if(!directout) {
 				const auto dst_path = final_dir + out.params.plot_name + ".plot";

--- a/src/chia_plot.cpp
+++ b/src/chia_plot.cpp
@@ -320,6 +320,10 @@ int main(int argc, char** argv)
 		std::cout << "Stagedir and tmptoggle are mutually exclusive options." << std::endl;
 		return -2;
 	}
+	if(!stage_dir.empty() && stage_dir.find_last_of("/\\") != stage_dir.size() - 1) {
+		std::cout << "Invalid stagedir: " << stage_dir << " (needs trailing '/' or '\\')" << std::endl;
+		return -2;
+	}
 	if(stage_dir.empty()) {
 		stage_dir = tmp_dir;
 	}
@@ -372,10 +376,6 @@ int main(int argc, char** argv)
 	}
 	if(!final_dir.empty() && final_dir.find_last_of("/\\") != final_dir.size() - 1) {
 		std::cout << "Invalid finaldir: " << final_dir << " (needs trailing '/' or '\\')" << std::endl;
-		return -2;
-	}
-	if(!stage_dir.empty() && stage_dir.find_last_of("/\\") != stage_dir.size() - 1) {
-		std::cout << "Invalid stagedir: " << stage_dir << " (needs trailing '/' or '\\')" << std::endl;
 		return -2;
 	}
 	if(num_threads < 1 || num_threads > 1024) {


### PR DESCRIPTION
If your final dir is a network share, you may wish to copy the file to a staging directory to then have a background thread copy to the network.

This allows me to keep be able to keep up speed. The build directory is a tmpfs, the stage directory is a local hard disk, and the final directory is a NFS share over 1 Gbe network. So it's rather slow.

I had to branch the code, to make other branches. So I'm resubmitting the pull request.