### PR TITLE
background logging with stats

### DIFF
--- a/include/chia/phase4.hpp
+++ b/include/chia/phase4.hpp
@@ -46,7 +46,8 @@ uint64_t compute(	FILE* plot_file,
 					const uint8_t k, const int header_size,
 					phase3::DiskSortNP* L_sort_7, int num_threads,
 					const uint64_t final_pointer_7,
-					const uint64_t final_entries_written)
+					const uint64_t final_entries_written,
+					std::ofstream* log_file = nullptr)
 {
 	const uint32_t P7_park_size = Util::ByteAlign((k + 1) * kEntriesPerPark) / 8;
     const uint64_t number_of_p7_parks =
@@ -78,7 +79,9 @@ uint64_t compute(	FILE* plot_file,
     
     std::vector<uintkx_t> C2;
 
-    std::cout << "[P4] Starting to write C1 and C3 tables" << std::endl;
+    std::ostringstream temp_buff;
+    temp_buff << "[P4] Starting to write C1 and C3 tables" << std::endl;
+    show_message(&temp_buff, log_file);
     
 	struct park_deltas_t {
 		uint64_t offset = 0;
@@ -214,8 +217,9 @@ uint64_t compute(	FILE* plot_file,
     final_file_writer_1 +=
     		fwrite_at(plot_file, final_file_writer_1, C1_entry_buf, Util::ByteAlign(k) / 8);
     
-    std::cout << "[P4] Finished writing C1 and C3 tables" << std::endl;
-    std::cout << "[P4] Writing C2 table" << std::endl;
+    temp_buff << "[P4] Finished writing C1 and C3 tables" << std::endl;
+    temp_buff << "[P4] Writing C2 table" << std::endl;
+    show_message(&temp_buff, log_file);
 
     for(auto C2_entry : C2) {
         Bits(C2_entry, k).ToBytes(C1_entry_buf);
@@ -226,7 +230,8 @@ uint64_t compute(	FILE* plot_file,
     final_file_writer_1 +=
     		fwrite_at(plot_file, final_file_writer_1, C1_entry_buf, Util::ByteAlign(k) / 8);
     
-    std::cout << "[P4] Finished writing C2 table" << std::endl;
+    temp_buff << "[P4] Finished writing C2 table" << std::endl;
+    show_message(&temp_buff, log_file);
 
     final_file_writer_1 = header_size - 8 * 3;
     uint8_t table_pointer_bytes[8] = {};
@@ -246,7 +251,8 @@ void compute(	const phase3::output_t& input, output_t& out,
 				const std::string plot_name,
 				const std::string tmp_dir,
 				const std::string tmp_dir_2,
-				const std::string plot_dir)
+				const std::string plot_dir,
+				std::ofstream* log_file = nullptr)
 {
 	const auto total_begin = get_wall_time_micros();
 	
@@ -256,7 +262,8 @@ void compute(	const phase3::output_t& input, output_t& out,
 	}
 	
 	out.plot_size = compute(plot_file, input.params.k, input.header_size, input.sort_7.get(),
-							num_threads, input.final_pointer_7, input.num_written_7);
+							num_threads, input.final_pointer_7,
+							input.num_written_7, log_file);
 	
 	fclose(plot_file);
 	
@@ -265,8 +272,11 @@ void compute(	const phase3::output_t& input, output_t& out,
 	
 	std::rename(input.plot_file_name.c_str(), out.plot_file_name.c_str());
 	
-	std::cout << "Phase 4 took " << (get_wall_time_micros() - total_begin) / 1e6 << " sec"
+	std::ostringstream temp_buff;
+	temp_buff << "Phase 4 took " << (get_wall_time_micros() - total_begin) / 1e6 << " sec"
 			", final plot size is " << out.plot_size << " bytes" << std::endl;
+	temp_buff << "Timestamp: " << get_date_string_ex("%Y/%m/%d %H:%M:%S") << std::endl;
+	show_message(&temp_buff, log_file);
 }
 
 


### PR DESCRIPTION
Add -l log file option to record most things going to std::cout in a log file. It also supports periodic (every 60 seconds) system stats to be added to the log for FreeBSD. The used sysctl calls should port to Linux with little changes, but I've not test on Linux.